### PR TITLE
Change directory before switching branches

### DIFF
--- a/git.rb
+++ b/git.rb
@@ -142,9 +142,14 @@ module Git
    end
 
    def self.switch_branch(branch)
+      # capture only the path, not the newline
+      basedir = `git rev-parse --show-toplevel`.split("\n").first
+
+      # change directory to base dir
+      Dir.chdir(basedir)
+
       self.run_safe("git checkout \"#{branch}\"")
       self.run_safe("git submodule --quiet update --init --recursive")
-
       self.run_safe("git clean -ffd") if ARGV.include?('--clean')
 
       self.show_stashes_saved_on(branch)


### PR DESCRIPTION
Running submodule update --init will error unless you are in your projects
TLD. Uses `git rev-parse --show-toplevel` to get the projects TLD.
