### PR TITLE
Fix switching branches with no stash.

### DIFF
--- a/git.rb
+++ b/git.rb
@@ -127,6 +127,11 @@ module Git
    end
 
    def self.stashes
+      # Do we even have a stash?
+      if ! File.exist? '.git/refs/stash'
+         return []
+      end
+
       # format = "relative date|stash ref|commit message"
       `git log --format="%ar|%gd|%s" -g "refs/stash"`.lines.map do |line|
          fields = line.split '|', 3


### PR DESCRIPTION
If you don't have any stashes, `.git/refs/stash` won't exist, so feeding
"refs/stash" into git-log gives an ugly error.  Since this was the last
thing that happened in feature-switch, it didn't cause any technical problems,
but it looked ugly.
