### PR TITLE
Allow alternate branch names in feature finish.

### DIFF
--- a/feature.rb
+++ b/feature.rb
@@ -69,7 +69,7 @@ when 'status'
 when 'finish'
    feature = ARGV[1] || Git::current_branch
    # Push commits to origin
-   Git::run_safe("git push")
+   Git::run_safe("git push origin #{feature}:#{feature}")
 
    exit 1 if !confirm("Create a pull-request for feature branch named: '#{feature}' ?")
    octokit = Github::api

--- a/hotfix.rb
+++ b/hotfix.rb
@@ -38,7 +38,7 @@ when 'finish'
    end
 
    # Push commits to origin
-   Git::run_safe("git push")
+   Git::run_safe("git push origin #{hotfix}:#{hotfix}")
 
    exit 1 if !confirm("Create a pull-request for hotfix branch named: '#{hotfix}' ?")
    octokit = Github::api


### PR DESCRIPTION
Previously, we'd just push whatever branch you were on - whoops!  Or
worse, if the user didn't have push.default set to 'current', we could
be pushing to any number of other branches; this is probably still a
problem a bunch of other places. :(
