### PR TITLE
Improve linkification of man pages in HTML.

### DIFF
--- a/man/feature.1.ronn
+++ b/man/feature.1.ronn
@@ -12,25 +12,25 @@ feature(1) - Perform actions on a git feature branch.
 
 ## COMMANDS
 
-   * `feature-list(1)`:
+   * feature-list(1):
       List the current branch and any available feature branches.
-   * `feature-start(1)`:
+   * feature-start(1):
       Start a new feature branch.
-   * `feature-switch(1)`:
+   * feature-switch(1):
       Switch to another feature branch.
-   * `feature-finish(1)`:
+   * feature-finish(1):
       Finish this feature branch (push and open a pull request).
-   * `feature-merge(1)`:
+   * feature-merge(1):
       Merge a feature branch into the development branch.
-   * `feature-pull(1)`:
+   * feature-pull(1):
       Pull remote updates into this branch.
-   * `feature-status(1)`:
+   * feature-status(1):
       Determine if the current branch is up-to-date with the remote branch.
-   * `feature-stashes(1)`:
+   * feature-stashes(1):
       Show stashes saved on the current branch.
-   * `feature-clean(1)`:
+   * feature-clean(1):
       Remove untracked files and submodules.
-   * `feature-github-test(1)`:
+   * feature-github-test(1):
       Test Github authentication.
 
 ## COPYRIGHT

--- a/man/hotfix.1.ronn
+++ b/man/hotfix.1.ronn
@@ -12,15 +12,15 @@ hotfix(1) - Perform actions on a git hotfix branch.
 
 ## COMMANDS
 
-   * `hotfix-list(1)`:
+   * hotfix-list(1):
       List the current branch and any available hotfix branches.
-   * `hotfix-start(1)`:
+   * hotfix-start(1):
       Start a new hotfix branch.
-   * `hotfix-switch(1)`:
+   * hotfix-switch(1):
       Switch to another hotfix branch.
-   * `hotfix-finish(1)`:
+   * hotfix-finish(1):
       Finish this hotfix branch (push and open a pull request).
-   * `hotfix-merge(1)`:
+   * hotfix-merge(1):
       Merge a hotfix branch into stable and the development branch.
 
 ## COPYRIGHT


### PR DESCRIPTION
If we backtick things, they don't get turned into links; if we don't,
they do!  As a bonus, this doesn't change how the actual man pages look.
