### PR TITLE
Fix pull, merge and start from non-TLDs

### DIFF
--- a/feature.rb
+++ b/feature.rb
@@ -23,7 +23,7 @@ when 'start'
    Git::run_safe("git branch \"#{feature}\" #{Git::development_branch}")
    Git::run_safe("git checkout \"#{feature}\"")
 
-   Git::init_submodules
+   Git::submodules_update
 
    # Automatically setup remote tracking branch
    Git::run_safe("git config branch.#{feature}.remote origin")
@@ -161,7 +161,7 @@ when 'pull'
    old_branch_hash = Git::branch_hash(current)
    Git::run_safe("git rebase --preserve-merges origin/#{current}")
 
-   Git::init_submodules
+   Git::submodules_update
 
    if Git::branch_hash(current) == old_branch_hash
       die "No changes in the remote branch. Your branch is up to date."

--- a/git.rb
+++ b/git.rb
@@ -148,24 +148,17 @@ module Git
 
    def self.switch_branch(branch)
       self.run_safe("git checkout \"#{branch}\"")
-      self.init_submodules
+      self.submodules_update
       self.run_safe("git clean -ffd") if ARGV.include?('--clean')
 
       self.show_stashes_saved_on(branch)
    end
 
-   def self.init_submodules
+   def self.submodules_update
       # capture only the path, not the newline
       basedir = `git rev-parse --show-toplevel`.split("\n").first
 
-      # change directory to base dir
-      Dir.chdir(basedir)
-
-      self.submodules_update
-   end
-
-   def self.submodules_update
-      Git::run_safe("git submodule --quiet update --init --rebase --recursive")
+      Git::run_safe("cd #{basedir} && git submodule --quiet update --init --rebase --recursive")
    end
 
    ##

--- a/hotfix.rb
+++ b/hotfix.rb
@@ -17,7 +17,7 @@ when 'start'
    Git::run_safe("git branch \"#{hotfix}\" stable")
    Git::run_safe("git checkout \"#{hotfix}\"")
 
-   Git::init_submodules
+   Git::submodules_update
 
    # Automatically setup remote tracking branch
    Git::run_safe("git config branch.#{hotfix}.remote origin")
@@ -91,7 +91,7 @@ when 'merge'
    Git::run_safe("git merge --no-ff --edit -m #{description.shellescape} \"#{hotfix}\"")
 
    # init any submodules in the stable branch
-   Git::init_submodules
+   Git::submodules_update
    # push the the merge to our origin
    # Git::run_safe("git push origin")
 


### PR DESCRIPTION
Pull #45 (f11ff4c) only fixed this for feature/hotfix switch. These
changes are needed any time git-submodule is run from somewhere other than the projects root.
