### PR TITLE
Hotfix: unify and improve hotfix branch name logic

### DIFF
--- a/bin/hotfix
+++ b/bin/hotfix
@@ -4,11 +4,10 @@ require_relative '../lib/git.rb'
 require_relative '../lib/helpers.rb'
 
 command=ARGV.first
-BRANCH_PREFIX = "hotfix-"
 case command
 when 'start'
    require_argument(:hotfix, :start)
-   hotfix = BRANCH_PREFIX + ARGV[1]
+   hotfix = hotix_branch(ARGV[1])
 
    exit if !confirm("Create hotfix branch named: '#{hotfix}' ?")
 
@@ -26,17 +25,12 @@ when 'start'
 
 when 'switch'
    require_argument(:hotfix, :switch, min=2, max=3)
-   hotfix = BRANCH_PREFIX + ARGV[1]
+   hotfix = current_hotfix_branch
 
    Git::switch_branch(hotfix)
 
 when 'finish'
-   hotfix = ARGV[1] || Git::current_branch
-
-   # ensure the hotfix name is the real branch name
-   if (!hotfix.start_with?("hotfix-"))
-       hotfix = "hotfix-" + hotfix
-   end
+   hotfix = current_hotfix_branch
 
    # Push commits to origin
    Git::run_safe("git push origin #{hotfix}:#{hotfix}")
@@ -64,14 +58,9 @@ when 'finish'
 when 'merge'
    fail_on_local_changes
    dev_branch = Git::development_branch
+   hotfix = current_hotfix_branch
 
    Git::run_safe("git fetch")
-
-   if ARGV[1]
-      hotfix = BRANCH_PREFIX + ARGV[1]
-   else
-      hotfix = Git::current_branch
-   end
 
    exit 1 if !confirm("Merge hotfix named: '#{hotfix}' ?")
 

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -130,6 +130,32 @@ def highlight(str)
    return HIGHLIGHT + str + HIGHLIGHT_OFF;
 end
 
+def hotfix_branch(name)
+   if name =~ /^hotfix-/
+     name
+   else
+     "hotfix-#{name}"
+   end
+end
+
+def current_hotfix_branch()
+   if ARGV[1]
+      branch = hotfix_branch(ARGV[1])
+   else
+      branch = Git::current_branch
+   end
+
+   if !is_hotfix_branch(branch)
+      puts "#{branch} is not a hotfix branch"
+      exit 1
+   end
+   branch
+end
+
+def is_hotfix_branch(name)
+   name =~ /^hotfix-/
+end
+
 def wrap_text(txt, col = 80)
    txt.gsub(
     /(.{1,#{col}})(?: +|$)\n?|(.{#{col}})/,


### PR DESCRIPTION
Now you can specify the full branch name, or the branch name without the
'hotfix-' prefix.

Equivalent:

```
hotfix switch hotfix-blah-blah
hotfix switch blah-blah
```
