### PR TITLE
Remove superfluous git-fetch.

### DIFF
--- a/bin/feature
+++ b/bin/feature
@@ -96,6 +96,7 @@ when 'finish'
 when 'merge'
    dev_branch = Git::development_branch
    fail_on_local_changes
+
    Git::run_safe("git fetch")
 
    feature = ARGV[1] || Git::current_branch
@@ -105,9 +106,7 @@ when 'merge'
    description = Github::get_pull_request_description_from_api(feature, dev_branch)
 
    # Checkout the branch first to make sure we have it locally.
-   Git::run_safe("git fetch")
    Git::run_safe("git checkout \"#{feature}\"")
-
    Git::run_safe("git rebase --preserve-merges origin/#{feature}")
 
    # pull the latest changes from master


### PR DESCRIPTION
We fetch at the beginning of feature-merge, and we'd fetch again soon
after for no good reason.  This issue was not present in hotfix-merge.
