### PR TITLE
Remove HEAD from branches.

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -55,7 +55,9 @@ module Git
    def self.all_branches()
       `git for-each-ref --sort=-committerdate --format='%(refname)' refs/heads refs/remotes`.
       split("\n").
-      map {|branch| branch.sub(/refs\/\w+\//, '') }.uniq
+      map {|branch| branch.sub(/refs\/\w+\//, '') }.
+      uniq.
+      reject {|branch| branch =~ %r{\w+/HEAD} }
    end
 
    # Returns the name of the currently checked out branch, or nil if detached.


### PR DESCRIPTION
Previously, doing a `feature list` showed HEAD as one of the branches.
This is silly, because HEAD isn't a branch.
