### PR TITLE
Notify the user to push after merging a feature.

### DIFF
--- a/bin/feature
+++ b/bin/feature
@@ -135,8 +135,6 @@ when 'merge'
    puts "Successfully merged feature-branch: #{feature} into #{dev_branch}"
    puts "If you are satisfied with the result, do this:\n" + <<CMDS
       git push
-      git checkout #{dev_branch}
-      git push
 CMDS
 
 when 'switch'


### PR DESCRIPTION
Fixes #72.

We do this on `hotfix merge` so why not on `feature merge`?
