### PR TITLE
Use one run_safe for `feature merge`.

### DIFF
--- a/bin/feature
+++ b/bin/feature
@@ -125,10 +125,6 @@ when 'merge'
       "#{update}",
       # delete the local feature-branch
       "git branch -d \"#{feature}\""
-      # delete the remote branch we'll leave this off for now
-      # Git::run_safe("git push origin :\"#{feature}\"")
-      # push the the merge to our origin
-      # Git::run_safe("git push origin")
    ])
 
    puts


### PR DESCRIPTION
This allows run_safe to print _all_ commands that would have run if the
merge was successful.
