### PR TITLE
Distinguish run_safe messages on error.

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -90,8 +90,8 @@ module Git
          unless system(command)
             puts highlight("\n\tERROR: failed on \`#{command}\`.")
             puts "\n\tWould have run:"
-            commands.each do |a|
-               puts "\t# " + a
+            commands.each do |command|
+               puts "\t# " + command
             end
             abort
          end


### PR DESCRIPTION
Adding newlines and highlighting the error will allow users to more
easily notice that their feature or hotfix command has failed.
