### PR TITLE
Add CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+We (obviously) use the same method on this repo as the tools contained within
+encourage.  Unfortunately, `feature finish` will create a pull request within
+your own forked repo.  Thus, if you do not have write privileges to this
+repository, you have to create the pull request manually - bummer.
+
+Please include any necessary changes to the documentation.  The man files are
+written in [ronn], so the only manual change you need make are to the
+man/*.ronn files.  After you've done that, run `rake man` to generate the HTML
+and roff files.
+
+[ronn]: http://rtomayko.github.io/ronn/ronn-format.7.html
+

--- a/README.md
+++ b/README.md
@@ -124,18 +124,3 @@ Merges the hotfix branch back into `stable` with `--no-ff`. Also does a
 merge back into `master`.
 
 [gitflow]: http://nvie.com/posts/a-successful-git-branching-model/
-
-## Hacking
-
-We (obviously) use the same method on this repo as the tools contained within
-encourage.  Unfortunately, `feature finish` will create a pull request within
-your own forked repo.  Thus, if you do not have write privileges to this
-repository, you have to create the pull request manually - bummer.
-
-Please include any necessary changes to the documentation.  The man files are
-written in [ronn], so the only manual change you need make are to the
-man/*.ronn files.  After you've done that, run `rake man` to generate the HTML
-and roff files.
-
-[ronn]: http://rtomayko.github.io/ronn/ronn-format.7.html
-


### PR DESCRIPTION
Remove the hacking section from the README and place it in CONTRIBUTING.
This takes advantage of github's nifty little feature that allows you to
view contributing rules when filing a new issue .
