### PR TITLE
Add useful error message when outside a git repo.

### DIFF
--- a/bin/feature
+++ b/bin/feature
@@ -10,7 +10,7 @@ $0 = ARGV.join(" ")
 
 unless command == '--help' or command == '-h'
    unless Git::in_a_repo
-      die("\nSwitch to a git repo.")
+      die("\nSwitch to a git repo. If you need help, use --help or -h.")
    end
 end
 

--- a/bin/hotfix
+++ b/bin/hotfix
@@ -10,7 +10,7 @@ $0 = ARGV.join(" ")
 
 unless command == '--help' or command == '-h'
    unless Git::in_a_repo
-      die("\nSwitch to a git repo.")
+      die("\nSwitch to a git repo. If you need help, use --help or -h.")
    end
 end
 


### PR DESCRIPTION
This will notify the dev of the help arguments when they're outside a
git repo.
