### PR TITLE
Commit-Status: use most recent status

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -180,7 +180,7 @@ Body of pull-request
       if pull
          # This will grab the latest commit and retrieve the state from it.
          sha = pull[:head][:sha]
-         state = octokit.statuses(repo, sha).shift
+         state = octokit.statuses(repo, sha).last
          state = state ? state[:state] : 'none'
 
          desc = <<-MSG


### PR DESCRIPTION
Instead of the oldest.

Github api returns statuses in oldest-first order, see:
https://api.github.com/repos/danielbeardsley/cimpler/statuses/3f0625b46ecb0c1d6789546f7c2f3d5b91a8ca5e

4 statuses, the last one is the the most recent.

Not sure how this is working for anyone as most commits have at least
two statuses (started, finished)
