### PR TITLE
git rebase: ensure --preseve-merges is always used

### DIFF
--- a/bin/feature
+++ b/bin/feature
@@ -32,7 +32,8 @@ when 'start'
 
    Git::run_safe([
       "git checkout #{development_branch}",
-      "git pull --rebase",
+      "git fetch",
+      "git rebase --preserve-merges origin/#{development_branch}",
       "git branch \"#{feature}\" #{development_branch}",
       "git checkout \"#{feature}\"",
    ])

--- a/bin/hotfix
+++ b/bin/hotfix
@@ -27,7 +27,8 @@ when 'start'
 
    Git::run_safe([
       "git checkout #{stable_branch}",
-      "git pull --rebase",
+      "git fetch",
+      "git rebase --preserve-merges origin/#{stable_branch}",
       "git branch \"#{hotfix}\" #{stable_branch}",
       "git checkout \"#{hotfix}\""
    ])
@@ -192,7 +193,7 @@ when 'merge'
       # Merge into master.
       "git checkout #{dev_branch}",
       # Pull the latest changes and rebase the unpushed master commits if any.
-      "git rebase origin/#{dev_branch}",
+      "git rebase --preserve-merges origin/#{dev_branch}",
       # Merge the hotfix branch into master.
       "git merge --no-ff --no-edit -m #{commit_message_dev.shellescape} \"#{hotfix}\"",
       # Init any submodules in the master branch. Note: no need to change.


### PR DESCRIPTION
If --preserved-merges is not used during a rebase and there is an
unpushed merge, the commits will be linearized (the merge commit
removed) and replayed on top of the origin with new hashes.

We had surely intended this to be so, but must have msised a few.
