### PR TITLE
hotfix/feature merge: push on successful merge

### DIFF
--- a/bin/feature
+++ b/bin/feature
@@ -213,7 +213,9 @@ when 'merge'
       # init any submodules in the master branch
       "#{update}",
       # delete the local feature-branch
-      "git branch -d \"#{feature}\""
+      "git branch -d \"#{feature}\"",
+      # Push that business to the origin
+      "git push origin \"#{dev_branch}\""
    ])
 
    puts

--- a/bin/hotfix
+++ b/bin/hotfix
@@ -203,7 +203,9 @@ when 'merge'
       # Delete the local hotfix branch.
       "git branch -d #{hotfix.shellescape}",
       # Checkout stable branch.
-      "git checkout #{stable_branch}"
+      "git checkout #{stable_branch}",
+      # Push both branches to the origin
+      "git push origin \"#{dev_branch}\" \"#{stable_branch}\""
    ])
 
    puts "Successfully merged hotfix branch: #{hotfix} into #{stable_branch} and #{dev_branch}"


### PR DESCRIPTION
We've historically done this by hand, but forgetting to push one or
both branches has been a source of frustration and confusion.

Automate all the things!

Git allows pushing as many branches as you want:
git push {remote_name} {branch1} {branch2} ...
