### PR TITLE
Update finish-issue docs

### DIFF
--- a/man/feature-finish-issue.1
+++ b/man/feature-finish-issue.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FEATURE\-FINISH\-ISSUE" "1" "September 2013" "iFixit" ""
+.TH "FEATURE\-FINISH\-ISSUE" "1" "February 2014" "iFixit" ""
 .
 .SH "NAME"
 \fBfeature\-finish\-issue\fR \- Finish this feature branch and attach it to an issue\.
 .
 .SH "SYNOPSIS"
-\fBfeature finish\fR \fIissue\-number\fR
+\fBfeature finish\-issue\fR \fIissue\-number\fR
 .
 .SH "DESCRIPTION"
 Finish the current feature branch and optionally convert an existing issue into a pull request\. The pull\'s description defaults to the commit message from the last commit on the branch with the issue\'s original title and description underneath\.

--- a/man/feature-finish-issue.1.ronn
+++ b/man/feature-finish-issue.1.ronn
@@ -3,7 +3,7 @@ feature-finish-issue(1) - Finish this feature branch and attach it to an issue.
 
 ## SYNOPSIS
 
-`feature finish` <issue-number>
+`feature finish-issue` <issue-number>
 
 ## DESCRIPTION
 

--- a/man/feature-finish.1
+++ b/man/feature-finish.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FEATURE\-FINISH" "1" "September 2013" "iFixit" ""
+.TH "FEATURE\-FINISH" "1" "February 2014" "iFixit" ""
 .
 .SH "NAME"
 \fBfeature\-finish\fR \- Finish this feature branch\.

--- a/man/feature.1
+++ b/man/feature.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FEATURE" "1" "September 2013" "iFixit" ""
+.TH "FEATURE" "1" "February 2014" "iFixit" ""
 .
 .SH "NAME"
 \fBfeature\fR \- Perform actions on a git feature branch\.
@@ -33,6 +33,10 @@ Switch to another feature branch\.
 .TP
 feature\-finish(1)
 Finish this feature branch (push and open a pull request)\.
+.
+.TP
+feature\-finish\-issue(1)
+Finish this feature branch and attach it to an issue\.
 .
 .TP
 feature\-merge(1)

--- a/man/feature.1.ronn
+++ b/man/feature.1.ronn
@@ -22,6 +22,8 @@ feature(1) - Perform actions on a git feature branch.
       Switch to another feature branch.
    * feature-finish(1):
       Finish this feature branch (push and open a pull request).
+   * feature-finish-issue(1):
+      Finish this feature branch and attach it to an issue.
    * feature-merge(1):
       Merge a feature branch into the development branch.
    * feature-pull(1):

--- a/man/hotfix-finish-issue.1
+++ b/man/hotfix-finish-issue.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "HOTFIX\-FINISH\-ISSUE" "1" "September 2013" "iFixit" ""
+.TH "HOTFIX\-FINISH\-ISSUE" "1" "February 2014" "iFixit" ""
 .
 .SH "NAME"
 \fBhotfix\-finish\-issue\fR \- Finish this hotfix branch and attach it to an issue\.
 .
 .SH "SYNOPSIS"
-\fBhotfix finish\fR \fIissue\-number\fR
+\fBhotfix finish\-issue\fR \fIissue\-number\fR
 .
 .SH "DESCRIPTION"
 Finish the current hotfix branch and optionally convert an existing issue into a pull request\. The pull\'s description defaults to the commit message from the last commit on the branch with the issue\'s original title and description underneath\.

--- a/man/hotfix-finish-issue.1.ronn
+++ b/man/hotfix-finish-issue.1.ronn
@@ -3,7 +3,7 @@ hotfix-finish-issue(1) - Finish this hotfix branch and attach it to an issue.
 
 ## SYNOPSIS
 
-`hotfix finish` <issue-number>
+`hotfix finish-issue` <issue-number>
 
 ## DESCRIPTION
 

--- a/man/hotfix-finish.1
+++ b/man/hotfix-finish.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "HOTFIX\-FINISH" "1" "September 2013" "iFixit" ""
+.TH "HOTFIX\-FINISH" "1" "February 2014" "iFixit" ""
 .
 .SH "NAME"
 \fBhotfix\-finish\fR \- Finish this hotfix branch\.

--- a/man/hotfix.1
+++ b/man/hotfix.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "HOTFIX" "1" "September 2013" "iFixit" ""
+.TH "HOTFIX" "1" "February 2014" "iFixit" ""
 .
 .SH "NAME"
 \fBhotfix\fR \- Perform actions on a git hotfix branch\.
@@ -33,6 +33,10 @@ Switch to another hotfix branch\.
 .TP
 hotfix\-finish(1)
 Finish this hotfix branch (push and open a pull request)\.
+.
+.TP
+hotfix\-finish\-issue(1)
+Finish this hotfix branch and attach it to an issue\.
 .
 .TP
 hotfix\-merge(1)

--- a/man/hotfix.1.ronn
+++ b/man/hotfix.1.ronn
@@ -22,6 +22,8 @@ hotfix(1) - Perform actions on a git hotfix branch.
       Switch to another hotfix branch.
    * hotfix-finish(1):
       Finish this hotfix branch (push and open a pull request).
+   * hotfix-finish-issue(1):
+      Finish this hotfix branch and attach it to an issue.
    * hotfix-merge(1):
       Merge a hotfix branch into stable and the development branch.
 


### PR DESCRIPTION
Turns out I only halfway completed the docs for finish-issue in #74.
This fixes the command name from `finish` to `finish-issue` and also
adds it to the feature and hotfix indices.
