### PR TITLE
feature/hotfix start: remove prompt

### DIFF
--- a/bin/feature
+++ b/bin/feature
@@ -25,7 +25,6 @@ when 'start'
    require_argument(:feature, :start)
    feature = ARGV[1]
 
-   exit unless confirm("Create feature branch named: '#{feature}' ?")
    development_branch = Git::get_branch('development')
 
    Plugins.invoke :before_start, :feature, feature

--- a/bin/hotfix
+++ b/bin/hotfix
@@ -21,8 +21,6 @@ when 'start'
    hotfix = hotfix_branch(ARGV[1])
    stable_branch = Git::get_branch('stable')
 
-   exit unless confirm("Create hotfix branch named: '#{hotfix}' ?")
-
    Plugins.invoke :before_start, :hotfix, hotfix
 
    Git::run_safe([


### PR DESCRIPTION
All the command does is create a branch and configure it, both of which are easily undone by deleting the branch.
