### PR TITLE
Add message-editing hook

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -140,6 +140,8 @@ Body of pull-request
       msg.write(message)
       msg.close
 
+      Plugins.invoke :pre_message_edit, msg.path
+
       editor = Git::editor
       if (editor == 'vim')
          opts = "'+set ft=gitcommit' '+set textwidth=72'" +


### PR DESCRIPTION
This allows us to write a plugin that automatically prefills CCs into
the pull request description.  Importantly, it happens _before_ the user
gets the message opened in their editor, so they can still edit it (it's
on the same level as the pre-fill from the last commit).
