### PR TITLE
Add Ruby 1.8 support

### DIFF
--- a/bin/feature
+++ b/bin/feature
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
+
+require 'rubygems'
+require 'require_relative'
+
 require_relative '../lib/signal_handlers.rb'
 require_relative '../lib/github.rb'
 require_relative '../lib/git.rb'

--- a/bin/hotfix
+++ b/bin/hotfix
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
+
+require 'rubygems'
+require 'require_relative'
+
 require_relative '../lib/signal_handlers.rb'
 require_relative '../lib/github.rb'
 require_relative '../lib/git.rb'

--- a/git-scripts.gemspec
+++ b/git-scripts.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
    s.add_dependency 'bundler'
    s.add_dependency 'octokit', '~> 1.22.0'
    s.add_dependency 'highline'
+   s.add_dependency 'require_relative'
 
    s.files = %w( COPYING Rakefile README.md  )
    s.files += Dir.glob 'completion/*'


### PR DESCRIPTION
I know it's absolutely ancient now, but since it's pretty easy to
support it, we might as well.

Am I supposed to modify `Gemfile.lock`?  I always forget.