### PR TITLE
Work with pagination

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -34,6 +34,8 @@ module Github
    # }
    ##
    def self.api(authorization_info = {})
+      # Let Octokit handle pagination automagically for us.
+      Octokit.auto_traversal = true
       # Defaults
       authorization_info = {
          :scopes => ['repo'],


### PR DESCRIPTION
@BaseInfinity pointed out to me that we were having problems merging a
particular pull.  With a bit of investigation, it turned out it wasn't just
that one - it was any pull that was fairly old.  This immediately brought to
mind pagination issues, which ended up being the case.

We can't use [the documented approach to pagination](https://octokit.github.io/octokit.rb/#Pagination) because Octokit is now
on version 3.2.0, and we're using [1.25.0](https://github.com/octokit/octokit.rb/releases/tag/v1.25.0). :)  So I cloned down the repo,
searched around, and did some guessing, and this approach appears to work:

Before:

```
[$]> ~/packages/git-scripts/bin/feature merge -n 1087
No pull request found for this branch.
Merge feature branch named: 'my-awesome-branch' ? (y/n): %
```

After:

```
[$]> ~/packages/git-scripts/bin/feature merge -n 1087
This pull request has failed to pass continuous integration tests. Merge with caution.
Merge feature branch named: 'my-awesome-branch' ? (y/n): %
```

CC @soriat
CC @sctice
CC @copperwall
