### PR TITLE
Gemspec: Specify exact version numbers for dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
-ruby "1.9.3"
 
 gemspec

--- a/git-scripts.gemspec
+++ b/git-scripts.gemspec
@@ -10,6 +10,11 @@ Gem::Specification.new do |s|
    s.email = ['daniel@ifixit.com', 'james@ifixit.com', 'tim@ifixit.com', 'robin@ifixit.com']
 
    s.add_dependency 'bundler'
+   s.add_dependency 'json', '~> 1.8.0'
+   s.add_dependency 'highline', '= 1.6.19'
+   s.add_dependency 'multi_json', '= 1.8.0'
+   s.add_dependency 'faraday', '= 0.8.8'
+   s.add_dependency 'faraday_middleware', '= 0.9.0'
    s.add_dependency 'octokit', '~> 1.22.0'
    s.add_dependency 'highline'
 

--- a/git-scripts.gemspec
+++ b/git-scripts.gemspec
@@ -10,13 +10,18 @@ Gem::Specification.new do |s|
    s.email = ['daniel@ifixit.com', 'james@ifixit.com', 'tim@ifixit.com', 'robin@ifixit.com']
 
    s.add_dependency 'bundler'
+   s.add_dependency 'octokit', '~> 1.22.0'
+
+   # These aren't strictly necessary. They are dependencies of octokit but we
+   # need to specify more precise versions of them because octokit didn't
+   # properly specify the version. Ideally we would upgrade octokit which
+   # would solve it but until we do that we need to specify these versions in
+   # order for the gem to work out of the box.
    s.add_dependency 'json', '~> 1.8.0'
-   s.add_dependency 'highline', '= 1.6.19'
    s.add_dependency 'multi_json', '= 1.8.0'
+   s.add_dependency 'highline', '= 1.6.19'
    s.add_dependency 'faraday', '= 0.8.8'
    s.add_dependency 'faraday_middleware', '= 0.9.0'
-   s.add_dependency 'octokit', '~> 1.22.0'
-   s.add_dependency 'highline'
 
    s.files = %w( COPYING Rakefile README.md  )
    s.files += Dir.glob 'completion/*'

--- a/git-scripts.gemspec
+++ b/git-scripts.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
    s.name = 'git-scripts'
-   s.version = '0.5.0'
+   s.version = '0.5.1'
    s.date = Time.now.strftime('%Y-%m-%d')
 
    s.authors = ['Daniel Beardsley', 'James Pearson', 'Tim Asp', 'Robin Choudhury']


### PR DESCRIPTION
Fresh installs of git-scripts weren't working because the way this version
of octokit specified its dependencies meant that a newer-than-previously
version of faraday ends up getting installed that didn't work with octokit.

Also, remove ruby version specifier cause this works in multiple ruby
versions.