### PR TITLE
Octokit 3.0.0

### DIFF
--- a/git-scripts.gemspec
+++ b/git-scripts.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
    s.email = ['daniel@ifixit.com', 'james@ifixit.com', 'tim@ifixit.com', 'robin@ifixit.com']
 
    s.add_dependency 'bundler'
-   s.add_dependency 'octokit', '~> 1.22.0'
+   s.add_dependency 'octokit', '~> 3.0.0'
 
    # These aren't strictly necessary. They are dependencies of octokit but we
    # need to specify more precise versions of them because octokit didn't
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
    s.add_dependency 'json', '~> 1.8.0'
    s.add_dependency 'multi_json', '= 1.8.0'
    s.add_dependency 'highline', '= 1.6.19'
-   s.add_dependency 'faraday', '= 0.8.8'
-   s.add_dependency 'faraday_middleware', '= 0.9.0'
+   s.add_dependency 'faraday'
+   s.add_dependency 'faraday_middleware'
 
    s.files = %w( COPYING Rakefile README.md  )
    s.files += Dir.glob 'completion/*'

--- a/git-scripts.gemspec
+++ b/git-scripts.gemspec
@@ -11,17 +11,8 @@ Gem::Specification.new do |s|
 
    s.add_dependency 'bundler'
    s.add_dependency 'octokit', '~> 3.0.0'
-
-   # These aren't strictly necessary. They are dependencies of octokit but we
-   # need to specify more precise versions of them because octokit didn't
-   # properly specify the version. Ideally we would upgrade octokit which
-   # would solve it but until we do that we need to specify these versions in
-   # order for the gem to work out of the box.
+   s.add_dependency 'highline'
    s.add_dependency 'json', '~> 1.8.0'
-   s.add_dependency 'multi_json', '= 1.8.0'
-   s.add_dependency 'highline', '= 1.6.19'
-   s.add_dependency 'faraday'
-   s.add_dependency 'faraday_middleware'
 
    s.files = %w( COPYING Rakefile README.md  )
    s.files += Dir.glob 'completion/*'

--- a/git-scripts.gemspec
+++ b/git-scripts.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
    s.name = 'git-scripts'
-   s.version = '0.5.1'
+   s.version = '0.6.0'
    s.date = Time.now.strftime('%Y-%m-%d')
 
    s.authors = ['Daniel Beardsley', 'James Pearson', 'Tim Asp', 'Robin Choudhury']

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -35,7 +35,7 @@ module Github
    ##
    def self.api(authorization_info = {})
       # Let Octokit handle pagination automagically for us.
-      Octokit.auto_traversal = true
+      Octokit.auto_paginate = true
       # Defaults
       authorization_info = {
          :scopes => ['repo'],
@@ -49,7 +49,7 @@ module Github
       username = self::config("github.user")
       token    = self::config("github.token")
       if !username.empty? && !token.empty?
-         return {:login => username, :oauth_token => token}
+         return {:login => username, :access_token => token}
       else
          return self::request_authorization(authorization_info)
       end
@@ -83,7 +83,7 @@ module Github
          die("Couldn't set git config")
       end
 
-      return {:login => username, :oauth_token => auth[:token]}
+      return {:login => username, :access_token => auth[:token]}
    end
 
    ##


### PR DESCRIPTION
Upgrades Octokit from version 1.22 to version 3.0.0 and fixes dependency issues
with faraday and faraday middleware.