### PR TITLE
feature merge: bail on merge conflicts

### DIFF
--- a/bin/feature
+++ b/bin/feature
@@ -199,9 +199,11 @@ when 'merge'
    exit 1 unless confirm("Merge feature branch named: '#{feature}' ?")
 
    update = Git::submodules_update("get")
-   pull_desc = pull_info[:description].shellescape
-   failure_message = highlight("Merge conflicts detected, merge #{dev_branch} into #{feature} and resolve conflicts.".shellescape)
-   abort_merge = "(git merge --abort && echo #{failure_message} && exit 1)"
+   pull_desc = pull_info[:description]
+   merge_failure_message =
+    "Merge conflicts detected, merge #{dev_branch} into #{feature} and resolve conflicts."
+   abort_merge =
+    "(git merge --abort && echo #{highlight(failure_message.shellescape)} && exit 1)"
 
    Git::run_safe([
       "git fetch",
@@ -213,7 +215,7 @@ when 'merge'
       # rebase the unpushed master commits if any.
       "git rebase --preserve-merges origin/#{dev_branch}",
       # merge the feature branch into master
-      "git merge --no-ff --edit -m #{pull_desc} \"#{feature}\" || #{abort_merge}",
+      "git merge --no-ff --edit -m #{pull_desc.shellescape} \"#{feature}\" || #{abort_merge}",
       # init any submodules in the master branch
       "#{update}",
       # delete the local feature-branch

--- a/bin/feature
+++ b/bin/feature
@@ -199,6 +199,9 @@ when 'merge'
    exit 1 unless confirm("Merge feature branch named: '#{feature}' ?")
 
    update = Git::submodules_update("get")
+   pull_desc = pull_info[:description].shellescape
+   failure_message = highlight("Merge conflicts detected, merge #{dev_branch} into #{feature} and resolve conflicts.".shellescape)
+   abort_merge = "(git merge --abort && echo #{failure_message} && exit 1)"
 
    Git::run_safe([
       "git fetch",
@@ -210,7 +213,7 @@ when 'merge'
       # rebase the unpushed master commits if any.
       "git rebase --preserve-merges origin/#{dev_branch}",
       # merge the feature branch into master
-      "git merge --no-ff --edit -m #{pull_info[:description].shellescape} \"#{feature}\"",
+      "git merge --no-ff --edit -m #{pull_desc} \"#{feature}\" || #{abort_merge}",
       # init any submodules in the master branch
       "#{update}",
       # delete the local feature-branch

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -131,12 +131,13 @@ module Git
 
    def self.run_safe(commands)
       while command = commands.shift
-         puts "> " + command
+         safe_command = command.gsub(/[^[:print:]]+/,' ')
+         puts "> " + safe_command
          unless system(command)
-            puts highlight("\n\tERROR: failed on \`#{command}\`.")
-            puts "\n\tWould have run:"
+            puts highlight("\nERROR: failed on #{safe_command}`.")
+            puts "\nWould have run:"
             commands.each do |command|
-               puts "\t# " + command
+               puts "# " + command.gsub(/[^[:print:]]+/,' ')
             end
             abort
          end


### PR DESCRIPTION
We had an issue recently where someone who was merging a pull
accidentally messed up a merge conflict resolution. Now, we bail on
merge conflicts, requiring master to be merged into the feature branch
to keep it up to date. This ensures that code review and CI builds
happen on exactly what will be in master, and merge conflict
resolutions will get proper review before getting merged back.