### PR TITLE
Fix failure_message variable typo

### DIFF
--- a/bin/feature
+++ b/bin/feature
@@ -203,7 +203,7 @@ when 'merge'
    merge_failure_message =
     "Merge conflicts detected, merge #{dev_branch} into #{feature} and resolve conflicts."
    abort_merge =
-    "(git merge --abort && echo #{highlight(failure_message.shellescape)} && exit 1)"
+    "(git merge --abort && echo #{highlight(merge_failure_message.shellescape)} && exit 1)"
 
    Git::run_safe([
       "git fetch",


### PR DESCRIPTION
Trying to merge a branch with merge conflicts fails due to an undefined
variable named `failure_message`. There's an unused variable named
`merge_failure_message` on the line above, so this corrects
`failure_message` to be `merge_failure_message`.