### PR TITLE
Git.rb: Add delete_current_branch function

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -111,6 +111,13 @@ module Git
       ref.split('/').last
    end
 
+   # Deletes the current branch. For cleaning up after errors.
+   def self.delete_current_branch()
+      branchName = Git::current_branch
+      Git::switch_branch('master')
+      `git branch -d #{branchName}`.strip
+   end
+
    # Returns the SHA1 hash that the specified branch or symbol points to
    def self.branch_hash(branch)
       `git rev-parse --verify --quiet "#{branch}" 2>/dev/null`.strip

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -113,9 +113,17 @@ module Git
 
    # Deletes the current branch. For cleaning up after errors.
    def self.delete_current_branch()
-      branchName = Git::current_branch
-      Git::switch_branch('master')
-      `git branch -d #{branchName}`.strip
+      devBranch = get_branch('development')
+      branch = Git::current_branch
+
+      if branch == devBranch
+         puts "Cannot remove development branch"
+         exit 1
+      end
+
+      Git::switch_branch(devBranch)
+
+      `git branch -d #{branch}`.strip
    end
 
    # Returns the SHA1 hash that the specified branch or symbol points to


### PR DESCRIPTION
I need this for the ifixit-scripts repo, in which I want to cancel
creation of an issue and associated branch if no issue description is
provided.

If we don't clean up the branch that we were on, when you retry
`feature start` to fix your problem, it claims that branch name already
exists.

I also tried doing the branch creation after issue creation, but that
made you go through labeling everything for nothing if the branch name
you chose was already taken.


Closes #145