### PR TITLE
Update the octokit version to 4.0.0

### DIFF
--- a/git-scripts.gemspec
+++ b/git-scripts.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
    s.email = ['daniel@ifixit.com', 'james@ifixit.com', 'tim@ifixit.com', 'robin@ifixit.com']
 
    s.add_dependency 'bundler'
-   s.add_dependency 'octokit', '~> 3.0.0'
+   s.add_dependency 'octokit', '~> 4.0.0'
    s.add_dependency 'highline'
    s.add_dependency 'json', '~> 1.8.0'
 


### PR DESCRIPTION
This update was required because their `labels` endpoint was limiting
the number of results before the update.

qa_req 0

Closes #148