### PR TITLE
Accept more valid branch names

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -108,7 +108,8 @@ module Git
    # Returns the name of the currently checked out branch, or nil if detached.
    def self.current_branch()
       ref = `git symbolic-ref -q HEAD`.strip
-      ref.split('/').last
+      ref.slice! "refs/heads/"
+      ref
    end
 
    # Deletes the current branch. For cleaning up after errors.

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -107,9 +107,7 @@ module Git
 
    # Returns the name of the currently checked out branch, or nil if detached.
    def self.current_branch()
-      ref = `git symbolic-ref -q HEAD`.strip
-      ref.slice! "refs/heads/"
-      ref
+      `git symbolic-ref -q --short HEAD`.strip
    end
 
    # Deletes the current branch. For cleaning up after errors.

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -104,10 +104,6 @@ def require_argument(program, command = nil, min = 2, max = 2)
    if (ARGV.length < min)
       help.call "Missing argument. This command requires exactly #{min} arguments."
    end
-
-   if (ARGV.last !~ /^[a-zA-z0-9-]+$/)
-      help.call "Invalid branch name: '#{ARGV.last}'"
-   end
 end
 
 ##


### PR DESCRIPTION
By more, I mean there are other characters allowed in git branch names
than previously allowed by this code.

The slice call on the ref takes care of stripping off the correct part
of the string.