### PR TITLE
Rubygems: fix crazy Gemfile bug

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -1,5 +1,3 @@
-require "rubygems"
-require "bundler/setup"
 require 'octokit'
 require 'shellwords'
 require 'readline'


### PR DESCRIPTION
Previously, if your project had a Gemfil in the root,
none of the feature scripts would work. they would crash with

   `require': cannot load such file -- octokit

As if it was somehow trying to use the Gemfil in the CWD as opposed to
its own..

I'm not sure exactly why, but dropping these two lines (which the docs
say are needed) fixes the issue :shurg:.