### PR TITLE
Bundler: require bundler in the entrypoint

### DIFF
--- a/bin/feature
+++ b/bin/feature
@@ -1,4 +1,7 @@
 #!/usr/bin/env ruby
+require 'rubygems'
+require 'bundler/setup'
+
 require_relative '../lib/signal_handlers.rb'
 require_relative '../lib/github.rb'
 require_relative '../lib/git.rb'


### PR DESCRIPTION
Otherwise, it will just load whichever versions are available
on the system. Or it will fail to if there's a Gemfile in the
current directory.