### PR TITLE
Add environment variable to specify issue repo

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -99,6 +99,10 @@ module Github
       end
    end
 
+   def self.get_issue_repo()
+      ENV['ISSUE_REPO'] ? ENV['ISSUE_REPO'] : get_github_repo
+   end
+
    ##
    # Prompts the user (using $EDITOR) to provide a title and body
    # for this pull-request


### PR DESCRIPTION
This is to support situations where the code / pull request is in one
repo, but the associated issue is in another repo.

This isn't used anywhere yet, but I want to make it available to
plugins.

cr_req 1
qa_req 0