### PR TITLE
Update bundler to avoid deprecation notices

### DIFF
--- a/git-scripts.gemspec
+++ b/git-scripts.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
               'copperwall@gmail.com',
               'robin@ifixit.com']
 
-   s.add_dependency 'bundler', '~> 1.17'
+   s.add_dependency 'bundler', '~> 2.1'
    s.add_dependency 'octokit', '~> 4.0'
    s.add_dependency 'json', '~> 1.8'
 


### PR DESCRIPTION
I'm not 100% sure this is necessary, but it seems to work in my testing.
I'm no longer getting the deprecation notice:
```
/usr/local/share/gems/gems/bundler-1.17.3/lib/bundler/rubygems_integration.rb:200:
warning: constant Gem::ConfigMap is deprecated
```